### PR TITLE
Added types blacklist when logging from use case decorator

### DIFF
--- a/petisco/controller/controller_decorator.py
+++ b/petisco/controller/controller_decorator.py
@@ -1,7 +1,7 @@
 import inspect
 from functools import wraps
 import traceback
-from typing import Callable, Tuple, Dict
+from typing import Callable, Tuple, Dict, List, Any
 
 from meiga import Result
 
@@ -30,12 +30,15 @@ class ControllerDecorator(object):
         success_handler: Callable[[Result], Tuple[Dict, int]] = None,
         error_handler: Callable[[Result], HttpError] = None,
         correlation_id_provider: Callable = flask_correlation_id_provider,
+        logging_types_blacklist: List[Any] = [bytes]
+
     ):
         self.logger = logger
         self.jwt_config = jwt_config
         self.success_handler = success_handler
         self.error_handler = error_handler
         self.correlation_id_provider = correlation_id_provider
+        self.logging_types_blacklist = logging_types_blacklist
 
     def __call__(self, func, *args, **kwargs):
         @wraps(func)
@@ -56,8 +59,13 @@ class ControllerDecorator(object):
                 if self.logger:
                     self.logger.log(INFO, log_message.to_json())
                 result = run_controller(*args, **kwargs)
-                log_message.message = f"{result}"
                 if result.is_success:
+                    if isinstance(result.value, tuple(self.logging_types_blacklist)):
+                        log_message.message = (
+                            f"Success result of type: {type(result.value).__name__}"
+                        )
+                    else:
+                        log_message.message = f"{result}"
                     if self.logger:
                         self.logger.log(INFO, log_message.to_json())
                     return (
@@ -67,6 +75,7 @@ class ControllerDecorator(object):
                     )
                 else:
                     if self.logger:
+                        log_message.message = f"{result}"
                         self.logger.log(ERROR, log_message.to_json())
                     known_result_failure_handler = KnownResultFailureHandler(result)
 

--- a/petisco/use_case/use_case_logger.py
+++ b/petisco/use_case/use_case_logger.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 
 from meiga import Result
 from meiga.decorators import meiga
@@ -9,9 +9,15 @@ from petisco.use_case.use_case import UseCase
 
 
 class UseCaseLogger(object):
-    def __init__(self, logger=None, logging_parameters_whitelist: List[str] = None):
+    def __init__(
+        self,
+        logger=None,
+        logging_parameters_whitelist: List[str] = None,
+        logging_types_blacklist: List[Any] = [bytes],
+    ):
         self.logger = logger
         self.logging_parameters_whitelist = logging_parameters_whitelist
+        self.logging_types_blacklist = logging_types_blacklist
 
     def __call__(self, cls):
         if not issubclass(cls, UseCase):
@@ -20,6 +26,7 @@ class UseCaseLogger(object):
         class UseCaseWrapped(cls):
             logger = self.logger
             logging_parameters_whitelist = self.logging_parameters_whitelist
+            logging_types_blacklist = self.logging_types_blacklist
 
             def execute(self, *args, **kwargs):
                 correlation_id = kwargs.get("correlation_id")
@@ -59,7 +66,12 @@ class UseCaseLogger(object):
                     log_message.message = f"{result} {detail}"
                     self.logger.log(ERROR, log_message.to_json())
                 else:
-                    log_message.message = f"{result.value}"
+                    if isinstance(result.value, tuple(self.logging_types_blacklist)):
+                        log_message.message = (
+                            f"Object of type: {type(result.value).__name__}"
+                        )
+                    else:
+                        log_message.message = f"{result.value}"
                     self.logger.log(INFO, log_message.to_json())
 
                 return result

--- a/tests/unit/controller/test_controller_logger.py
+++ b/tests/unit/controller/test_controller_logger.py
@@ -153,3 +153,34 @@ def test_should_execute_successfully_a_empty_controller_without_input_parameters
     http_response = my_controller()
 
     assert http_response == ({"message": "OK"}, 200)
+
+
+@pytest.mark.unit
+def test_should_execute_successfully_a_filtered_object_by_blacklist():
+
+    logger = FakeLogger()
+
+    @controller(logger=logger)
+    def my_controller():
+        return Success(b"This are bytes")
+
+    http_response = my_controller()
+
+    assert http_response == ({"message": "OK"}, 200)
+
+    first_logging_message = logger.get_logging_messages()[0]
+    second_logging_message = logger.get_logging_messages()[1]
+
+    assert first_logging_message == (
+        INFO,
+        LogMessageMother.get_controller(
+            operation="my_controller", message="Start"
+        ).to_json(),
+    )
+    assert second_logging_message == (
+        INFO,
+        LogMessageMother.get_controller(
+            operation="my_controller",
+            message="Success result of type: bytes",
+        ).to_json(),
+    )

--- a/tests/unit/use_case/test_use_case.py
+++ b/tests/unit/use_case/test_use_case.py
@@ -1,7 +1,7 @@
 import pytest
 
 from petisco import UseCase, use_case_logger, INFO
-from meiga import Result
+from meiga import Result, Success
 
 from tests.unit.mocks.fake_logger import FakeLogger
 from tests.unit.mocks.log_message_mother import LogMessageMother
@@ -94,5 +94,32 @@ def test_should_log_successfully_a_non_error_use_case_with_input_parameters():
         INFO,
         LogMessageMother.get_use_case(
             operation="MyUseCase", message="Hello Petisco"
+        ).to_json(),
+    )
+
+
+@pytest.mark.unit
+def test_should_log_successfully_a_filtered_object_by_blacklist():
+
+    logger = FakeLogger()
+
+    @use_case_logger(logger=logger, logging_types_blacklist=[bytes])
+    class MyUseCase(UseCase):
+        def execute(self):
+            return Success(b"This are bytes")
+
+    MyUseCase().execute()
+
+    first_logging_message = logger.get_logging_messages()[0]
+    second_logging_message = logger.get_logging_messages()[1]
+
+    assert first_logging_message == (
+        INFO,
+        LogMessageMother.get_use_case(operation="MyUseCase", message="Start").to_json(),
+    )
+    assert second_logging_message == (
+        INFO,
+        LogMessageMother.get_use_case(
+            operation="MyUseCase", message="Object of type: bytes"
         ).to_json(),
     )


### PR DESCRIPTION
Added a blacklist of types to use-case and controller decorator that prevents from logging undesirable objects such as Bytes. On contrary, it will substitute the object itself by a string containing its type name.