### PR TITLE
Add optional flag allow_utf8mb4 (default: True) 

### DIFF
--- a/petisco/domain/value_objects/string_value_object.py
+++ b/petisco/domain/value_objects/string_value_object.py
@@ -41,11 +41,13 @@ class StringValueObject(ValueObject):
             raise raise_cls()
 
     def _ensure_value_contains_valid_char(
-        self, raise_cls=InvalidStringValueObjectError
+        self, raise_cls=InvalidStringValueObjectError, allow_utf8mb4: bool = True
     ):
         if not isinstance(self.value, str) or not re.search(
             r"^[\w]*(([',. -][\s]?[\w]?)?[\w]*)*$", self.value
         ):
+            self._raise_error(raise_cls)
+        if not allow_utf8mb4 and re.match("[^\u0000-\uffff]", self.value):
             self._raise_error(raise_cls)
 
     def _ensure_value_is_less_than_n_char(

--- a/tests/unit/domain/value_objects/test_string_value_object.py
+++ b/tests/unit/domain/value_objects/test_string_value_object.py
@@ -1,6 +1,9 @@
 import pytest
 
-from petisco.domain.value_objects.string_value_object import StringValueObject
+from petisco.domain.value_objects.string_value_object import (
+    StringValueObject,
+    InvalidStringValueObjectError,
+)
 from petisco.domain.value_objects.value_object import ValueObjectError
 
 
@@ -46,4 +49,24 @@ def test_should_inherit_from_string_value_object_and_add_an_ensure_clause():
 
     invalid_value = "a" * 35
     with pytest.raises(ValueObjectError):
+        Name(invalid_value)
+
+
+@pytest.mark.unit
+def test_should_inherit_from_string_value_object_and_raise_exception_when_not_supporting_utf8mb4():
+    class Name(StringValueObject):
+        def __init__(self, value: str):
+            super(Name, self).__init__(value)
+
+        def guard(self):
+            self._ensure_value_contains_valid_char(allow_utf8mb4=False)
+
+    value = "Alex"
+    name = Name(value)
+
+    assert isinstance(name, Name)
+    assert name.value == value
+
+    invalid_value = "𝘼𝙡𝙚𝙭"
+    with pytest.raises(InvalidStringValueObjectError):
         Name(invalid_value)


### PR DESCRIPTION
To _ensure_value_contains_valid_char of StringValueObject

This can be used to prevent inserting not supported strings to MySQL DBs that
only support 3-byte UTF strings