### PR TITLE
Proposal for multiple SQL persistence sources

### DIFF
--- a/petisco/fixtures/persistence.py
+++ b/petisco/fixtures/persistence.py
@@ -21,8 +21,8 @@ def petisco_sql_database():
                 "Please add required SQL_DATABASE env variable (e.g pytest.ini, pytest.end2end.ini)"
             )
 
-        Base = SqlAlchemyPersistence.get_instance().base
-        Session = SqlAlchemyPersistence.get_instance().session
+        Base = SqlAlchemyPersistence.get_instance().connections["petisco"]["base"]
+        Session = SqlAlchemyPersistence.get_instance().connections["petisco"]["session"]
         connection = f"sqlite:///{sql_database}"
         engine = create_engine(connection)
         Base.metadata.create_all(engine)

--- a/petisco/modules/healthcheck/application/healthcheck_provider.py
+++ b/petisco/modules/healthcheck/application/healthcheck_provider.py
@@ -17,7 +17,7 @@ class HealthcheckProvider(UseCase):
                 session_scope,
             )
 
-            with session_scope() as session:
+            with session_scope("petisco") as session:
                 try:
                     session.execute("SELECT 1")
                 except Exception as e:

--- a/petisco/persistence/sqlalchemy/sqlalchemy_persistence.py
+++ b/petisco/persistence/sqlalchemy/sqlalchemy_persistence.py
@@ -6,6 +6,5 @@ class SqlAlchemyPersistence(metaclass=Singleton):
     def get_instance():
         return SqlAlchemyPersistence()
 
-    def __init__(self, session=None, base=None):
-        self.session = session
-        self.base = base
+    def __init__(self):
+        self.connections = {}

--- a/petisco/persistence/sqlalchemy/sqlalchemy_session_scope.py
+++ b/petisco/persistence/sqlalchemy/sqlalchemy_session_scope.py
@@ -8,9 +8,11 @@ from petisco.persistence.sqlalchemy.sqlalchemy_persistence import SqlAlchemyPers
 
 
 @contextmanager
-def session_scope():
+def session_scope(connection: str):
     """Provide a transactional scope around a series of operations."""
-    transactional_scope = SqlAlchemyPersistence.get_instance().session()
+    transactional_scope = SqlAlchemyPersistence.get_instance().connections[connection][
+        "session"
+    ]()
     try:
         yield transactional_scope
         transactional_scope.commit()

--- a/tests/integration/flask_app/toy_app/config/config_persistence.py
+++ b/tests/integration/flask_app/toy_app/config/config_persistence.py
@@ -6,7 +6,7 @@ def config_persistence(import_database_models: Callable):
 
     config = SqlAlchemyPersistenceConfig(server="sqlite", database="petisco.db")
     persistence_connector = SqlAlchemyPersistenceConnector(
-        config=config, import_database_models=import_database_models
+        config=config, name="petisco", import_database_models=import_database_models
     )
 
     persistence_connector.execute()

--- a/tests/integration/flask_app/toy_app/infrastructure/repositories/sql_user_repository.py
+++ b/tests/integration/flask_app/toy_app/infrastructure/repositories/sql_user_repository.py
@@ -23,7 +23,7 @@ class SqlUserRepository(IUserRepository):
     def build():
         return SqlUserRepository(
             session_scope=Petisco.persistence_session_scope(),
-            user_model=Petisco.get_persistence_model("user"),
+            user_model=Petisco.get_persistence_model("petisco", "user"),
         )
 
     def __init__(self, session_scope: Callable, user_model: Any):
@@ -39,7 +39,7 @@ class SqlUserRepository(IUserRepository):
         if result.is_success:
             return Failure(UserAlreadyExistError(user.user_id))
 
-        with self.session_scope() as session:
+        with self.session_scope("petisco") as session:
             user = self.UserModel(
                 client_id=user.client_id.value,
                 user_id=user.user_id.value,
@@ -50,7 +50,7 @@ class SqlUserRepository(IUserRepository):
 
     def retrieve(self, client_id: ClientId, user_id: UserId) -> Result[User, Error]:
 
-        with self.session_scope() as session:
+        with self.session_scope("petisco") as session:
             user_model = (
                 session.query(self.UserModel)
                 .filter(self.UserModel.client_id == client_id.value)
@@ -69,7 +69,7 @@ class SqlUserRepository(IUserRepository):
             )
 
     def exists(self, user_id: UserId) -> Result[bool, Error]:
-        with self.session_scope() as session:
+        with self.session_scope("petisco") as session:
             user = (
                 session.query(self.UserModel)
                 .filter(self.UserModel.user_id == user_id.value)

--- a/tests/integration/flask_app/toy_app/infrastructure/repositories/user_model.py
+++ b/tests/integration/flask_app/toy_app/infrastructure/repositories/user_model.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String
 from petisco.persistence.sqlalchemy.sqlalchemy_persistence import SqlAlchemyPersistence
 
-Base = SqlAlchemyPersistence.get_instance().base
+Base = SqlAlchemyPersistence.get_instance().connections["petisco"]["base"]
 
 
 class UserModel(Base):

--- a/tests/integration/flask_app/toy_app/petisco.yml
+++ b/tests/integration/flask_app/toy_app/petisco.yml
@@ -18,9 +18,10 @@ framework:
 logger:
     selected_logger: not_implemented_logger
 persistence:
-  config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
-  models:
-    user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
+  - name: petisco
+    config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
+    models:
+      user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
 providers:
    services_provider: tests.integration.flask_app.toy_app.config.services_provider.services_provider
    repositories_provider: tests.integration.flask_app.toy_app.config.repositories_provider.repositories_provider

--- a/tests/unit/application/test_config.py
+++ b/tests/unit/application/test_config.py
@@ -1,7 +1,7 @@
-from typing import Callable
+import os
+from typing import Callable, Dict
 
 import pytest
-import os
 
 from petisco.application.config.config import Config
 
@@ -20,8 +20,9 @@ def test_should_load_complete_petisco_yml(petisco_yml_path):
 
     assert len(config.config_tasks.tasks.keys()) == 3
 
-    assert isinstance(config.config_persistence.config, Callable)
-    assert config.config_persistence.models is not None
+    assert isinstance(config.config_persistence.configs, Dict)
+    assert isinstance(config.config_persistence.configs["petisco"].config, Callable)
+    assert config.config_persistence.configs["petisco"].models is not None
 
     assert isinstance(config.config_providers.services_provider, Callable)
     assert isinstance(config.config_providers.repositories_provider, Callable)
@@ -35,8 +36,9 @@ def test_should_load_a_petisco_yml_with_no_events(petisco_yml_path):
 
     config = Config.from_filename(filename).unwrap()
 
-    assert isinstance(config.config_persistence.config, Callable)
-    assert config.config_persistence.models is not None
+    assert isinstance(config.config_persistence.configs, Dict)
+    assert isinstance(config.config_persistence.configs["petisco"].config, Callable)
+    assert config.config_persistence.configs["petisco"].models is not None
 
     assert isinstance(config.config_providers.services_provider, Callable)
     assert isinstance(config.config_providers.repositories_provider, Callable)
@@ -49,8 +51,9 @@ def test_should_load_a_petisco_yml_with_events_no_subscribers(petisco_yml_path):
 
     config = Config.from_filename(filename).unwrap()
 
-    assert isinstance(config.config_persistence.config, Callable)
-    assert config.config_persistence.models is not None
+    assert isinstance(config.config_persistence.configs, Dict)
+    assert isinstance(config.config_persistence.configs["petisco"].config, Callable)
+    assert config.config_persistence.configs["petisco"].models is not None
 
     assert isinstance(config.config_providers.services_provider, Callable)
     assert isinstance(config.config_providers.repositories_provider, Callable)

--- a/tests/unit/application/ymls/petisco.all.yml
+++ b/tests/unit/application/ymls/petisco.all.yml
@@ -17,9 +17,10 @@ framework:
 logger:
   selected_logger: not_implemented_logger
 persistence:
-  config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
-  models:
-    user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
+  - name: petisco
+    config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
+    models:
+      user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
 providers:
    services_provider: tests.integration.flask_app.toy_app.config.services_provider.services_provider
    repositories_provider: tests.integration.flask_app.toy_app.config.repositories_provider.repositories_provider

--- a/tests/unit/application/ymls/petisco.events.nosubscribers.yml
+++ b/tests/unit/application/ymls/petisco.events.nosubscribers.yml
@@ -8,9 +8,10 @@ framework:
 logger:
   selected_logger: not_implemented_logger
 persistence:
-  config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
-  models:
-    user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
+  - name: petisco
+    config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
+    models:
+      user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
 providers:
    services_provider: tests.integration.flask_app.toy_app.config.services_provider.services_provider
    repositories_provider: tests.integration.flask_app.toy_app.config.repositories_provider.repositories_provider

--- a/tests/unit/application/ymls/petisco.noevents.yml
+++ b/tests/unit/application/ymls/petisco.noevents.yml
@@ -8,9 +8,10 @@ framework:
 logger:
   selected_logger: not_implemented_logger
 persistence:
-  config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
-  models:
-    user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
+  - name: petisco
+    config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
+    models:
+      user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
 providers:
    services_provider: tests.integration.flask_app.toy_app.config.services_provider.services_provider
    repositories_provider: tests.integration.flask_app.toy_app.config.repositories_provider.repositories_provider


### PR DESCRIPTION
Currently Petisco doesn't support working with multiple SQL persistence sources.
In this proposal the persistence config is now defined as a list:

```
persistence:
  - name: petisco
    config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
    models:
      user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
```
instead of:
```
persistence:
    config: tests.integration.flask_app.toy_app.config.config_persistence.config_persistence
    models:
      user: tests.integration.flask_app.toy_app.infrastructure.repositories.user_model.UserModel
```
This way we could add multiple sources.

Then in our SQL repositories we have to explicitly select a persistence source when retrieving the models and when using a session:

```
class SqlUserRepository(IUserRepository):
    @staticmethod
    def build():
        return SqlUserRepository(
            session_scope=Petisco.persistence_session_scope(),
            user_model=Petisco.get_persistence_model("petisco", "user"),
        )
```

```
 with self.session_scope("petisco") as session:
```