### PR TITLE
Fix issues with multiple persistence sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ We can use [petisco_client](petisco/fixtures/client.py) to simulate our client i
 import pytest
 
 @pytest.mark.acceptance
+@pytest.mark.persistence_source("acme")
 def test_should_return_200_when_call_healthcheck(
     petisco_client
 ):
@@ -271,6 +272,9 @@ def test_should_return_200_when_call_healthcheck(
 
 Included in *petisco_client* we can find [petisco_sql_database](petisco/fixtures/persistence.py).
 This fixture will create and connect a database and after the test this will be deleted.
+
+Note that to use these fixtures you must indicate with a marker the persistence source. In the above example the 
+persistence source is named `acme`.
 
 
 #### Extras

--- a/petisco/application/petisco.py
+++ b/petisco/application/petisco.py
@@ -40,7 +40,7 @@ class Petisco(metaclass=Singleton):
     options: Dict[str, Any] = None
     info: Dict = None
     _persistence_models: Dict[str, Dict[str, Any]] = None
-    persistence_configured: Dict[str, bool] = None
+    persistence_sources: Dict[str, Dict] = None
     config: Config = None
     event_publisher: IEventPublisher = None
     event_subscriber: IEventSubscriber = None
@@ -131,7 +131,7 @@ class Petisco(metaclass=Singleton):
 
     def _set_persistence(self):
         self._persistence_models = {}
-        self.persistence_configured = {}
+        self.persistence_sources = {}
         config_persistence = self.config.config_persistence
         if config_persistence.configs:
             for config_key, config_value in config_persistence.configs.items():
@@ -146,7 +146,10 @@ class Petisco(metaclass=Singleton):
                     ] = config_persistence.get_models(config_key)
                 else:
                     config_value.config()
-                self.persistence_configured[config_key] = True
+                self.persistence_sources[config_key] = {
+                    "configured": True,
+                    "type": config_value.type,
+                }
 
     def _set_services_and_repositories_from_providers(self):
         config_providers = self.config.config_providers

--- a/petisco/fixtures/persistence.py
+++ b/petisco/fixtures/persistence.py
@@ -6,8 +6,17 @@ from petisco.application.petisco import Petisco
 
 
 @pytest.fixture
-def petisco_sql_database():
-    if not Petisco.get_instance().persistence_configured:
+def petisco_sql_database(request):
+    persistence_source_marker = request.node.get_closest_marker("persistence_source")
+    if persistence_source_marker is None:
+        persistence_source_name = "petisco"
+    else:
+        persistence_source_name = persistence_source_marker.args[0]
+
+    persistence_source_config = Petisco.get_instance().persistence_sources[
+        persistence_source_name
+    ]
+    if not persistence_source_config or not persistence_source_config["configured"]:
         yield
     else:
         from sqlalchemy import create_engine
@@ -21,8 +30,12 @@ def petisco_sql_database():
                 "Please add required SQL_DATABASE env variable (e.g pytest.ini, pytest.end2end.ini)"
             )
 
-        Base = SqlAlchemyPersistence.get_instance().connections["petisco"]["base"]
-        Session = SqlAlchemyPersistence.get_instance().connections["petisco"]["session"]
+        Base = SqlAlchemyPersistence.get_instance().sources[persistence_source_name][
+            "base"
+        ]
+        Session = SqlAlchemyPersistence.get_instance().sources[persistence_source_name][
+            "session"
+        ]
         connection = f"sqlite:///{sql_database}"
         engine = create_engine(connection)
         Base.metadata.create_all(engine)

--- a/petisco/modules/healthcheck/application/healthcheck_provider.py
+++ b/petisco/modules/healthcheck/application/healthcheck_provider.py
@@ -12,16 +12,21 @@ class HealthcheckProvider(UseCase):
 
         healthcheck = {"app_name": petisco.app_name, "app_version": petisco.app_version}
 
-        if petisco.persistence_configured:
+        if petisco.persistence_sources:
             from petisco.persistence.sqlalchemy.sqlalchemy_session_scope import (
                 session_scope,
             )
 
-            with session_scope("petisco") as session:
-                try:
-                    session.execute("SELECT 1")
-                except Exception as e:
-                    return Failure(PersistenceError(str(e)))
+            for (
+                persistence_source_name,
+                persistence_source,
+            ) in petisco.persistence_sources.items():
+                if persistence_source["type"] == "sql":
+                    with session_scope(persistence_source_name) as session:
+                        try:
+                            session.execute("SELECT 1")
+                        except Exception as e:
+                            return Failure(PersistenceError(str(e)))
             healthcheck["persistence_available"] = True
 
         return Success(healthcheck)

--- a/petisco/persistence/sqlalchemy/sqlalchemy_persistence.py
+++ b/petisco/persistence/sqlalchemy/sqlalchemy_persistence.py
@@ -7,4 +7,4 @@ class SqlAlchemyPersistence(metaclass=Singleton):
         return SqlAlchemyPersistence()
 
     def __init__(self):
-        self.connections = {}
+        self.sources = {}

--- a/petisco/persistence/sqlalchemy/sqlalchemy_persistence_connector.py
+++ b/petisco/persistence/sqlalchemy/sqlalchemy_persistence_connector.py
@@ -45,7 +45,7 @@ class SqlAlchemyPersistenceConnector(IPersistenceConnector):
         base = declarative_base()
 
         persistence = SqlAlchemyPersistence()
-        persistence.connections[self.name] = {"base": base}
+        persistence.sources[self.name] = {"base": base}
 
         self.import_database_models()
 
@@ -71,7 +71,7 @@ class SqlAlchemyPersistenceConnector(IPersistenceConnector):
 
         if not database_exists(engine.url):
             create_database(engine.url)
-            persistence.connections[self.name]["base"].metadata.create_all(engine)
+            persistence.sources[self.name]["base"].metadata.create_all(engine)
 
         session = sessionmaker(bind=engine)
-        persistence.connections[self.name]["session"] = session
+        persistence.sources[self.name]["session"] = session

--- a/petisco/persistence/sqlalchemy/sqlalchemy_session_scope.py
+++ b/petisco/persistence/sqlalchemy/sqlalchemy_session_scope.py
@@ -8,9 +8,9 @@ from petisco.persistence.sqlalchemy.sqlalchemy_persistence import SqlAlchemyPers
 
 
 @contextmanager
-def session_scope(connection: str):
+def session_scope(source: str):
     """Provide a transactional scope around a series of operations."""
-    transactional_scope = SqlAlchemyPersistence.get_instance().connections[connection][
+    transactional_scope = SqlAlchemyPersistence.get_instance().sources[source][
         "session"
     ]()
     try:

--- a/tests/integration/flask_app/test_flask_application.py
+++ b/tests/integration/flask_app/test_flask_application.py
@@ -5,21 +5,11 @@ from petisco.domain.value_objects.user_id import UserId
 from petisco.frameworks.flask.flask_extension_is_installed import (
     flask_extension_is_installed,
 )
-from petisco.persistence.pymongo.mongodb_is_running_locally import (
-    mongodb_is_running_locally,
-)
-from tests.integration.flask_app.fixtures import host, username, password, port
 
 
 @pytest.mark.integration
 @pytest.mark.skipif(
     not flask_extension_is_installed(), reason="Flask extension is not installed"
-)
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
 )
 def test_should_return_200_when_call_healthcheck_with_happy_path(petisco_client):
     headers = {"Accept": "toy_app/json"}
@@ -38,12 +28,6 @@ def test_should_return_200_when_call_healthcheck_with_happy_path(petisco_client)
 @pytest.mark.skipif(
     not flask_extension_is_installed(), reason="Flask extension is not installed"
 )
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
-)
 def test_should_return_200_when_call_environment_with_happy_path_with_apikey(
     petisco_client, given_any_apikey
 ):
@@ -56,12 +40,6 @@ def test_should_return_200_when_call_environment_with_happy_path_with_apikey(
 @pytest.mark.skipif(
     not flask_extension_is_installed(), reason="Flask extension is not installed"
 )
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
-)
 def test_should_return_401_when_call_environment_with_happy_path_without_apikey(
     petisco_client
 ):
@@ -73,12 +51,6 @@ def test_should_return_401_when_call_environment_with_happy_path_without_apikey(
 @pytest.mark.integration
 @pytest.mark.skipif(
     not flask_extension_is_installed(), reason="Flask extension is not installed"
-)
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
 )
 def test_should_return_200_when_call_sum_with_valid_values(petisco_client):
     headers = {
@@ -100,12 +72,6 @@ def test_should_return_200_when_call_sum_with_valid_values(petisco_client):
 @pytest.mark.integration
 @pytest.mark.skipif(
     not flask_extension_is_installed(), reason="Flask extension is not installed"
-)
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
 )
 def test_should_return_200_when_call_sum_with_valid_values_with_external_headers(
     petisco_client
@@ -132,12 +98,6 @@ def test_should_return_200_when_call_sum_with_valid_values_with_external_headers
 @pytest.mark.integration
 @pytest.mark.skipif(
     not flask_extension_is_installed(), reason="Flask extension is not installed"
-)
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
 )
 def test_should_return_400_when_call_sum_without_required_value(petisco_client):
     headers = {"Content-Type": "multipart/form-data"}

--- a/tests/integration/flask_app/test_flask_application_jwt_tokens_and_sqlalchemy_persistence.py
+++ b/tests/integration/flask_app/test_flask_application_jwt_tokens_and_sqlalchemy_persistence.py
@@ -4,13 +4,9 @@ from petisco.domain.value_objects.user_id import UserId
 from petisco.frameworks.flask.flask_extension_is_installed import (
     flask_extension_is_installed,
 )
-from petisco.persistence.pymongo.mongodb_is_running_locally import (
-    mongodb_is_running_locally,
-)
 from petisco.persistence.sqlalchemy.sqlalchemy_extension_is_installed import (
     sqlalchemy_extension_is_installed,
 )
-from tests.integration.flask_app.fixtures import host, username, password, port
 
 
 @pytest.mark.integration
@@ -20,12 +16,6 @@ from tests.integration.flask_app.fixtures import host, username, password, port
 @pytest.mark.skipif(
     not sqlalchemy_extension_is_installed(),
     reason="SQLAlchemy extension is not installed",
-)
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
 )
 def test_should_return_200_when_call_a_entry_point_with_required_jwt_type_token(
     petisco_client, given_auth_token_headers_creator, given_any_name
@@ -47,12 +37,6 @@ def test_should_return_200_when_call_a_entry_point_with_required_jwt_type_token(
     not sqlalchemy_extension_is_installed(),
     reason="SQLAlchemy extension is not installed",
 )
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
-)
 def test_should_return_401_when_call_a_entry_point_with_required_jwt_type_token(
     petisco_client, given_auth_token_headers_creator, given_any_name
 ):
@@ -73,12 +57,6 @@ def test_should_return_401_when_call_a_entry_point_with_required_jwt_type_token(
 @pytest.mark.skipif(
     not sqlalchemy_extension_is_installed(),
     reason="SQLAlchemy extension is not installed",
-)
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
 )
 def test_should_return_200_when_call_a_entry_point_with_required_jwt_type_token_and_user_id(
     petisco_client, given_auth_token_headers_creator, given_any_name
@@ -106,12 +84,6 @@ def test_should_return_200_when_call_a_entry_point_with_required_jwt_type_token_
     not sqlalchemy_extension_is_installed(),
     reason="SQLAlchemy extension is not installed",
 )
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
-)
 def test_should_return_401_when_call_a_entry_point_with_required_jwt_type_token_with_user_and_user_is_not_available(
     petisco_client, given_auth_token_headers_creator
 ):
@@ -130,12 +102,6 @@ def test_should_return_401_when_call_a_entry_point_with_required_jwt_type_token_
 @pytest.mark.skipif(
     not sqlalchemy_extension_is_installed(),
     reason="SQLAlchemy extension is not installed",
-)
-@pytest.mark.skipif(
-    not mongodb_is_running_locally(
-        host=host, username=username, password=password, port=port
-    ),
-    reason="MongoDB is not running locally",
 )
 def test_should_return_409_when_call_create_user_with_invalid_name(
     petisco_client, given_auth_token_headers_creator, given_code_injection_name

--- a/tests/integration/flask_app/toy_app/infrastructure/repositories/user_model.py
+++ b/tests/integration/flask_app/toy_app/infrastructure/repositories/user_model.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String
 from petisco.persistence.sqlalchemy.sqlalchemy_persistence import SqlAlchemyPersistence
 
-Base = SqlAlchemyPersistence.get_instance().connections["petisco"]["base"]
+Base = SqlAlchemyPersistence.get_instance().sources["petisco"]["base"]
 
 
 class UserModel(Base):


### PR DESCRIPTION
- Use a marker to provide persistence source name when using petisco_sql_database
fixture. If not provided defaults to "petisco"
- Change healthcheck behavior to take into account multiple persistence sources.
For the moment only do a healtcheck for SQL sources