### PR TITLE
Replace depecrated set-env in Github action

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Set RELEASE_VERSION
-      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
+      run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
     - name: Update VERSION file
       run: echo ${RELEASE_VERSION} > ${PACKAGE_NAME}/VERSION
     - name: Install dependencies


### PR DESCRIPTION
See:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/