### PR TITLE
Add new task type "cron"

### DIFF
--- a/petisco/tasks/config/config_task.py
+++ b/petisco/tasks/config/config_task.py
@@ -17,14 +17,18 @@ def get_float_if_exist(kdict: Dict, value: str, default_value=None) -> float:
     return value
 
 
-def get_type(run_in, interval) -> str:
+def get_type(run_in, interval, every) -> str:
     if interval:
         type_task = "recurring"
     else:
+
         if run_in:
             type_task = "scheduled"
         else:
-            type_task = "instant"
+            if every:
+                type_task = "cron"
+            else:
+                type_task = "instant"
     return type_task
 
 
@@ -34,6 +38,7 @@ class ConfigTask:
     run_in: float = 0.0
     interval: float = None
     type: str = "instant"
+    every: str = None
     kdict: Dict = None
 
     def to_dict(self):
@@ -42,6 +47,8 @@ class ConfigTask:
             kdict["run_in"] = self.run_in
         if self.interval is not None:
             kdict["interval"] = self.interval
+        if self.every is not None:
+            kdict["every"] = self.every
         return kdict
 
     @staticmethod
@@ -49,15 +56,17 @@ class ConfigTask:
         run_in = get_float_if_exist(kdict, "run_in", default_value=0.0)
         interval = get_float_if_exist(kdict, "interval")
         handler_key = kdict.get("handler")
-        type = get_type(run_in, interval)
+        every = kdict.get("every", None)
+        type = get_type(run_in, interval, every)
 
         if not handler_key:
-            raise TypeError(f"ConfigTask: handler is a required parameter")
+            raise TypeError("ConfigTask: handler is a required parameter")
 
         return ConfigTask(
             run_in=run_in,
             handler_key=handler_key,
             interval=interval,
+            every=every,
             type=type,
             kdict=kdict,
         )

--- a/petisco/tasks/infrastructure/apscheduler_task_executor.py
+++ b/petisco/tasks/infrastructure/apscheduler_task_executor.py
@@ -8,6 +8,7 @@ from apscheduler.schedulers import (
 from apscheduler.schedulers.blocking import BlockingScheduler
 
 from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
 
 from petisco.tasks.config.config_tasks import ConfigTasks
 from petisco.tasks.domain.interface_task_executor import TaskExecutor
@@ -31,6 +32,8 @@ class APSchedulerTaskExecutor(TaskExecutor):
             self._config_recurring_task(task)
         elif task.type == "scheduled":
             self._config_scheduled_task(task)
+        elif task.type == "cron":
+            self._config_cron_task(task)
         else:
             self._config_instant_task(task)
 
@@ -49,6 +52,11 @@ class APSchedulerTaskExecutor(TaskExecutor):
         start_date = now + timedelta(0, task.run_in)
         self.scheduler.add_job(
             func=task.get_handler(), trigger="date", run_date=start_date
+        )
+
+    def _config_cron_task(self, task):
+        self.scheduler.add_job(
+            func=task.get_handler(), trigger=CronTrigger.from_crontab(task.every)
         )
 
     def _config_instant_task(self, task):


### PR DESCRIPTION
See: #140

These tasks have a field "every" that admits a crontab expression to schedule
tasks

For example, with this config:

```yaml
  cron:
    every: "33 * * * *"
    handler: taskmanager.src.modules.dummy.tasks.cron_task
```

The task `cron_task` will be executed every day and every hour at
the 33rd minute

More info on crontab expressions on webs like https://crontab.guru/