### PR TITLE
Set required SQLAlchemy version [1.3.11,1.4.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,11 @@ setup(
             "Flask-Cors==3.0.7",
             "Flask-Bcrypt==0.7.1",
         ],
-        "sqlalchemy": ["sqlalchemy>=1.3.11", "sqlalchemy_utils", "PyMySQL==0.9.2"],
+        "sqlalchemy": [
+            "sqlalchemy<1.4.0,>=1.3.11",
+            "sqlalchemy_utils",
+            "PyMySQL==0.9.2",
+        ],
         "redis": ["redis >= 3.3.11", "fakeredis>=1.0.5"],
         "rabbitmq": ["pika==1.1.0"],
         "gunicorn": ["gunicorn", "json-logging-py==0.2"],


### PR DESCRIPTION
SQLAlchemy 1.4.0 breaks Petisco persistence