### PR TITLE
Fix check of utf8mb4 characters in string value object guard

### DIFF
--- a/petisco/domain/value_objects/string_value_object.py
+++ b/petisco/domain/value_objects/string_value_object.py
@@ -48,8 +48,14 @@ class StringValueObject(ValueObject):
             r"^[\w]*(([',. -][\s]?[\w]?)?[\w]*)*$", self.value
         ):
             self._raise_error(raise_cls)
-        if not allow_utf8mb4 and re.match("[^\u0000-\uffff]", self.value):
-            self._raise_error(raise_cls)
+        if not allow_utf8mb4:
+            if not all(
+                [
+                    re.match("[^\u0000-\uffff]", char) is None
+                    for char in list(self.value)
+                ]
+            ):
+                self._raise_error(raise_cls)
 
     def _ensure_value_is_less_than_n_char(
         self, max_num_chars: int, raise_cls=ExceedLengthLimitValueObjectError

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,6 @@ pytest-variables[yaml]
 pytest-clarity
 requests-mock==1.8.0
 hypothesis==4.34.0
-pre-commit==1.18.3
+pre-commit==2.9.2
 twine==1.13.0
 fakeredis==1.1.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,7 +6,7 @@ backports-datetime-fromisoformat>=1.0.0;python_version<"3.7"
 pyjwt==2.1.0
 cryptography>=2.1.4
 py-healthcheck==1.7.2
-APScheduler==3.6.3
+APScheduler==3.7.0
 pyyaml
 deprecation
 slackclient==2.5.0

--- a/tests/modules/unit/domain/value_objects/test_string_value_object.py
+++ b/tests/modules/unit/domain/value_objects/test_string_value_object.py
@@ -53,7 +53,10 @@ def test_should_inherit_from_string_value_object_and_add_an_ensure_clause():
 
 
 @pytest.mark.unit
-def test_should_inherit_from_string_value_object_and_raise_exception_when_not_supporting_utf8mb4():
+@pytest.mark.parametrize("value", ["Alex", "Íñigo", "João"])
+def test_should_inherit_from_string_value_object_with_disallowed_utf8mb4_and_create_objects_successfully(
+    value,
+):
     class Name(StringValueObject):
         def __init__(self, value: str):
             super(Name, self).__init__(value)
@@ -61,12 +64,22 @@ def test_should_inherit_from_string_value_object_and_raise_exception_when_not_su
         def guard(self):
             self._ensure_value_contains_valid_char(allow_utf8mb4=False)
 
-    value = "Alex"
     name = Name(value)
-
     assert isinstance(name, Name)
     assert name.value == value
 
-    invalid_value = "𝘼𝙡𝙚𝙭"
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["𝘼𝙡𝙚𝙭", "Alex𖥔", "Alex😃"])
+def test_should_inherit_from_string_value_object_with_disallowed_utf8mb4_and_raise_exception_with_utf8mb4_values(
+    value,
+):
+    class Name(StringValueObject):
+        def __init__(self, value: str):
+            super(Name, self).__init__(value)
+
+        def guard(self):
+            self._ensure_value_contains_valid_char(allow_utf8mb4=False)
+
     with pytest.raises(InvalidStringValueObjectError):
-        Name(invalid_value)
+        Name(value)


### PR DESCRIPTION
Upgrade **pre-commit** version to enable black hook
> The hook `black` requires pre-commit version 2.9.2 but version 1.18.3 is installed

Upgrade **APScheduler** version due broken dependencies ([info](https://github.com/agronholm/apscheduler/issues/536))