### PR TITLE
Inject error traces in apm

### DIFF
--- a/petisco/controller/controller_handler.py
+++ b/petisco/controller/controller_handler.py
@@ -291,6 +291,11 @@ class _ControllerHandler:
                 http_response = http_error.handle()
         else:
             http_response = known_result_failure_handler.http_error.handle()
+        if apm_extension_is_installed():
+            import elasticapm
+
+            elasticapm.set_custom_context({"http_response": http_response})
+
         return http_response
 
 

--- a/petisco/controller/controller_handler.py
+++ b/petisco/controller/controller_handler.py
@@ -200,6 +200,10 @@ class _ControllerHandler:
                         info_petisco=Petisco.get_info(),
                     )
                 )
+                if apm_extension_is_installed():
+                    import elasticapm
+
+                    elasticapm.set_custom_context({"internal_error_message": message})
 
             if self.send_request_responded_event:
 

--- a/petisco/persistence/elastic/apm_extension_is_installed.py
+++ b/petisco/persistence/elastic/apm_extension_is_installed.py
@@ -1,7 +1,0 @@
-def apm_extension_is_installed() -> bool:
-    try:
-        import elasticapm  # noqa: F401
-
-        return True
-    except ModuleNotFoundError:
-        return False

--- a/tests/modules/unit/controller/test_controller_handler.py
+++ b/tests/modules/unit/controller/test_controller_handler.py
@@ -144,8 +144,12 @@ def test_should_execute_successfully_a_empty_controller_with_correlation_id_as_o
 
 
 @pytest.mark.unit
+@patch.object(elasticapm, "set_custom_context")
 def test_should_execute_with_a_failure_a_empty_controller_without_input_parameters(
-    given_any_petisco, given_any_info_id, given_headers_provider
+    elastic_apm_set_custom_context_mock,
+    given_any_petisco,
+    given_any_info_id,
+    given_headers_provider,
 ):
 
     logger = FakeLogger()
@@ -163,6 +167,10 @@ def test_should_execute_with_a_failure_a_empty_controller_without_input_paramete
         {"error": {"message": "Unknown Error", "type": "HttpError"}},
         500,
     )
+
+    elastic_apm_set_custom_context_mock.assert_called_once()
+    apm_set_custom_context_arg = elastic_apm_set_custom_context_mock.call_args[0][0]
+    assert apm_set_custom_context_arg["http_response"] == http_response
 
     first_logging_message = logger.get_logging_messages()[0]
     second_logging_message = logger.get_logging_messages()[1]
@@ -184,6 +192,27 @@ def test_should_execute_with_a_failure_a_empty_controller_without_input_paramete
             info_id=given_any_info_id,
         ).to_dict(),
     )
+
+
+@pytest.mark.unit
+@patch(
+    "petisco.controller.controller_handler.apm_extension_is_installed",
+    return_value=False,
+)
+@patch.object(elasticapm, "set_custom_context")
+def test_should_execute_with_a_failure_without_inject_http_response_in_apm_due_is_not_installed(
+    elastic_apm_set_custom_context_mock,
+    apm_extension_is_installed_mock,
+    given_any_petisco,
+):
+    @controller_handler()
+    def my_controller():
+        return isFailure
+
+    my_controller()
+
+    apm_extension_is_installed_mock.assert_called_once()
+    elastic_apm_set_custom_context_mock.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/modules/unit/controller/test_controller_handler.py
+++ b/tests/modules/unit/controller/test_controller_handler.py
@@ -195,27 +195,6 @@ def test_should_execute_with_a_failure_a_empty_controller_without_input_paramete
 
 
 @pytest.mark.unit
-@patch(
-    "petisco.controller.controller_handler.apm_extension_is_installed",
-    return_value=False,
-)
-@patch.object(elasticapm, "set_custom_context")
-def test_should_execute_with_a_failure_without_inject_http_response_in_apm_due_is_not_installed(
-    elastic_apm_set_custom_context_mock,
-    apm_extension_is_installed_mock,
-    given_any_petisco,
-):
-    @controller_handler()
-    def my_controller():
-        return isFailure
-
-    my_controller()
-
-    apm_extension_is_installed_mock.assert_called_once()
-    elastic_apm_set_custom_context_mock.assert_not_called()
-
-
-@pytest.mark.unit
 def test_should_execute_with_a_failure_a_empty_controller_with_correlation_id_as_only_input_parameter(
     given_any_petisco, given_any_info_id, given_headers_provider
 ):

--- a/tests/modules/unit/controller/test_controller_handler.py
+++ b/tests/modules/unit/controller/test_controller_handler.py
@@ -310,8 +310,12 @@ def test_should_execute_successfully_a_filtered_object_by_blacklist(
 
 
 @pytest.mark.unit
+@patch.object(elasticapm, "set_custom_context")
 def test_should_log_an_exception_occurred_on_the_controller(
-    given_any_petisco, given_any_info_id, given_headers_provider
+    elastic_apm_set_custom_context_mock,
+    given_any_petisco,
+    given_any_info_id,
+    given_headers_provider,
 ):
 
     logger = FakeLogger()
@@ -332,6 +336,12 @@ def test_should_log_an_exception_occurred_on_the_controller(
 
     first_logging_message = logger.get_logging_messages()[0]
     second_logging_message = logger.get_logging_messages()[1]
+    elastic_apm_set_custom_context_mock.assert_called_once()
+    apm_set_custom_context_arg = elastic_apm_set_custom_context_mock.call_args[0][0]
+    assert (
+        apm_set_custom_context_arg["internal_error_message"]
+        == second_logging_message[1]["data"]["message"]
+    )
 
     assert first_logging_message == (
         DEBUG,


### PR DESCRIPTION
- :information_source: We use `elasticapm.set_custom_context` instead `elasticapm.label` because is information used for debugging and it is not indexed so we cannot do searches and dashboards based in this data (see [doc](https://www.elastic.co/guide/en/apm/get-started/current/metadata.html#custom-fields))

- **elastic-apm** dependency is defined in `requirements.txt`, so, it always will be installed. On this way, always will try to inject error response and trace in _APM_ if there is a transaction, else will ignore it