### PR TITLE
FIX. Controller. Ensure run middleware (after) when result mapper raise an exception

### DIFF
--- a/petisco/base/misc/wrapper.py
+++ b/petisco/base/misc/wrapper.py
@@ -63,10 +63,12 @@ def wrapper(execute_func, wrapped_class_name, config, mapper):
             )
             result = Failure(unknown_error)
 
-        mapped_result = mapper.map(result)
         for middleware in middlewares:
             if result:
                 middleware.after(result)
+
+        mapped_result = mapper.map(result)
+
         return mapped_result
 
     return wrapped

--- a/tests/modules/extra/fastapi/controller/unit/test_fastapi_controller.py
+++ b/tests/modules/extra/fastapi/controller/unit/test_fastapi_controller.py
@@ -163,9 +163,9 @@ def test_fastapi_controller_should_execute_middleware_when_controller_raise_an_u
         with patch.object(
             PrintMiddleware, "after", return_value=isSuccess
         ) as mock_middleware_after:
-            result = MyController().execute()
+            with pytest.raises(Exception):
+                MyController().execute()
 
-    assert result.is_failure
     mock_middleware_before.assert_called()
     mock_middleware_after.assert_called()
 

--- a/tests/modules/extra/fastapi/controller/unit/test_fastapi_controller.py
+++ b/tests/modules/extra/fastapi/controller/unit/test_fastapi_controller.py
@@ -163,7 +163,7 @@ def test_fastapi_controller_should_execute_middleware_when_controller_raise_an_u
         with patch.object(
             PrintMiddleware, "after", return_value=isSuccess
         ) as mock_middleware_after:
-            with pytest.raises(Exception):
+            with pytest.raises(HTTPException):
                 MyController().execute()
 
     mock_middleware_before.assert_called()

--- a/tests/modules/extra/fastapi/controller/unit/test_fastapi_controller.py
+++ b/tests/modules/extra/fastapi/controller/unit/test_fastapi_controller.py
@@ -149,6 +149,28 @@ def test_fastapi_controller_should_return_success_result_with_middlewares(
 
 
 @pytest.mark.unit
+def test_fastapi_controller_should_execute_middleware_when_controller_raise_an_unexpected_exception():
+    class MyController(FastAPIController):
+        class Config:
+            middlewares = [PrintMiddleware]
+
+        def execute(self) -> BoolResult:
+            raise Exception()
+
+    with patch.object(
+        PrintMiddleware, "before", return_value=isSuccess
+    ) as mock_middleware_before:
+        with patch.object(
+            PrintMiddleware, "after", return_value=isSuccess
+        ) as mock_middleware_after:
+            result = MyController().execute()
+
+    assert result.is_failure
+    mock_middleware_before.assert_called()
+    mock_middleware_after.assert_called()
+
+
+@pytest.mark.unit
 def test_fastapi_controller_should_success_with_all_configurations_when_success_result():
     class MyController(FastAPIController):
         class Config:


### PR DESCRIPTION
I think the problem is in the wrapper, when an fastapi controller return an error, the fastapi result mapper raise an `HTTPException` and the middlware (after method) is not executed

> AssertionError: Expected 'after' to have been called

The solution is do the mapping after run middleware (after)

:memo: Note: There were doubts about this, notifier middleware only notifies `UnknownError` that are generated by unexpected errors (it does not notify controlled ones with correspondent domain errors..) I understand that this is the expected behaviour