### PR TITLE
fix(controller_handler): add InfoId check before trying to inject APM…

### DIFF
--- a/petisco/controller/controller_handler.py
+++ b/petisco/controller/controller_handler.py
@@ -214,7 +214,7 @@ class _ControllerHandler:
 
                 self.event_bus.publish(request_responded)
 
-            if self.inject_apm_metadata:
+            if self.inject_apm_metadata and info_id:
                 elasticapm.label(
                     client_id=info_id.to_dict()["client_id"],
                     user_id=info_id.to_dict()["user_id"],


### PR DESCRIPTION
… labels

If there is an error with the tokens the TokenManager won't be able to
extract the InfoId so we need to take this into account when injecting
the APM labels