### PR TITLE
docs: improve message-broker readme

### DIFF
--- a/.github/workflows/ci.macos.yml
+++ b/.github/workflows/ci.macos.yml
@@ -3,7 +3,7 @@ name: ci-macos
 on:
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'petisco/VERSION'
       - '.github/ISSUE_TEMPLATE'
       - '.github/workflows/coverage.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'petisco/VERSION'
       - '.github/ISSUE_TEMPLATE'
       - '.github/workflows/coverage.yml'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: coverage
 on:
   push:
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'petisco/VERSION'
       - '.github/ISSUE_TEMPLATE'
       - '.github/workflows/ci.yml'

--- a/doc/message_broker/MessageBroker.md
+++ b/doc/message_broker/MessageBroker.md
@@ -4,6 +4,7 @@
 
 This page is an overview of how petisco helps us on Message Broker development. 
 
+
 ## 1. Getting Started
 
 > **Note**

--- a/doc/message_broker/MessageBroker.md
+++ b/doc/message_broker/MessageBroker.md
@@ -55,27 +55,31 @@ To test how petisco can help you on message management you need to run locally a
     ```
     You can check the RabbitMQ status on [http://localhost:15672/#/](http://localhost:15672/#/) (guest:guest). Please, 
     check the official doc [here](https://www.rabbitmq.com/download.html).
-2. Create a python environment and install petisco
+2. Clone the project
+    ```console
+    git clone git@github.com:alice-biometrics/petisco.git && cd petisco
+    ```
+4. Create a python environment and install petisco
     ```console
     > python3 -m venv venv
     > source venv/bin/activate
     (venv) > pip install petisco[rabbitmq]
     ```
-3. **Configure the exchanges and queues**. This script will configure common queues and specific queues to support subscriptions (domain event and command consumers/handlers).
+5. **Configure the exchanges and queues**. This script will configure common queues and specific queues to support subscriptions (domain event and command consumers/handlers).
     ```console
-    python examples/rabbitmq/configure.py
+    python3 -m examples.rabbitmq.configure
     ```
-4. **Start consuming messages from Queues**. This script will execute a continuous process to consume every message on subscribed queues. 
+6. **Start consuming messages from Queues**. This script will execute a continuous process to consume every message on subscribed queues. 
     ```console
-    python examples/rabbitmq/consume.py
+    python3 -m examples.rabbitmq.consume
     ```
-5. **Publish domain events**.
+7. **Publish domain events**.
     ```console
-    python examples/rabbitmq/publish_domain_events.py
+    python3 -m examples.rabbitmq.publish_domain_events
     ```
-6. **Dispatch commands**.
+8. **Dispatch commands**.
     ```console
-    python examples/rabbitmq/dispatch_commands.py
+    python3 -m examples.rabbitmq.dispatch_commands
     ```
 
 These examples can help you to start playing with rabbitmq and to understand how it works in petisco. It is strongly 
@@ -114,8 +118,8 @@ Imagine you have some events in a dead letter queue. To reproduce, you can confi
 events without launching a consumer. 
 
 ```console
-python examples/rabbitmq/configure.py
-python examples/rabbitmq/publish_domain_events.py
+python3 -m examples.rabbitmq.configure
+python3 -m examples.rabbitmq.publish_domain_events
 ```
 
 To requeue event from queues, just use the `petisco-rabbitmq`

--- a/doc/message_broker/MessageBroker.md
+++ b/doc/message_broker/MessageBroker.md
@@ -58,25 +58,25 @@ To test how petisco can help you on message management you need to run locally a
     ```console
     git clone git@github.com:alice-biometrics/petisco.git && cd petisco
     ```
-4. Create a python environment and install petisco
+3. Create a python environment and install petisco
     ```console
     > python3 -m venv venv
     > source venv/bin/activate
     (venv) > pip install petisco[rabbitmq]
     ```
-5. **Configure the exchanges and queues**. This script will configure common queues and specific queues to support subscriptions (domain event and command consumers/handlers).
+4. **Configure the exchanges and queues**. This script will configure common queues and specific queues to support subscriptions (domain event and command consumers/handlers).
     ```console
     python3 -m examples.rabbitmq.configure
     ```
-6. **Start consuming messages from Queues**. This script will execute a continuous process to consume every message on subscribed queues. 
+5. **Start consuming messages from Queues**. This script will execute a continuous process to consume every message on subscribed queues. 
     ```console
     python3 -m examples.rabbitmq.consume
     ```
-7. **Publish domain events**.
+6. **Publish domain events**.
     ```console
     python3 -m examples.rabbitmq.publish_domain_events
     ```
-8. **Dispatch commands**.
+7. **Dispatch commands**.
     ```console
     python3 -m examples.rabbitmq.dispatch_commands
     ```

--- a/doc/message_broker/MessageBroker.md
+++ b/doc/message_broker/MessageBroker.md
@@ -62,23 +62,24 @@ To test how petisco can help you on message management you need to run locally a
     ```console
     > python3 -m venv venv
     > source venv/bin/activate
-    (venv) > pip install petisco[rabbitmq]
+    (venv) > pip install lume
+    (venv) > lume -install
     ```
 4. **Configure the exchanges and queues**. This script will configure common queues and specific queues to support subscriptions (domain event and command consumers/handlers).
     ```console
-    python3 -m examples.rabbitmq.configure
+    python3 examples/rabbitmq/configure.py
     ```
 5. **Start consuming messages from Queues**. This script will execute a continuous process to consume every message on subscribed queues. 
     ```console
-    python3 -m examples.rabbitmq.consume
+    python3 examples/rabbitmq/consume.py
     ```
 6. **Publish domain events**.
     ```console
-    python3 -m examples.rabbitmq.publish_domain_events
+    python3 examples/rabbitmq/publish_domain_events.py
     ```
 7. **Dispatch commands**.
     ```console
-    python3 -m examples.rabbitmq.dispatch_commands
+    python3 examples/rabbitmq/dispatch_commands.py
     ```
 
 These examples can help you to start playing with rabbitmq and to understand how it works in petisco. It is strongly 
@@ -117,8 +118,8 @@ Imagine you have some events in a dead letter queue. To reproduce, you can confi
 events without launching a consumer. 
 
 ```console
-python3 -m examples.rabbitmq.configure
-python3 -m examples.rabbitmq.publish_domain_events
+python3 examples/rabbitmq/configure.py
+python3 examples/rabbitmq/publish_domain_events.py
 ```
 
 To requeue event from queues, just use the `petisco-rabbitmq`

--- a/doc/message_broker/MessageBroker.md
+++ b/doc/message_broker/MessageBroker.md
@@ -4,7 +4,6 @@
 
 This page is an overview of how petisco helps us on Message Broker development. 
 
-
 ## 1. Getting Started
 
 > **Note**


### PR DESCRIPTION
- Add clone of the project to can run scripts
- Run scripts as modules to avoid import failures

In addition I have added any Markdown files to exclude in CI workflows ([doc](https://docs.github.com/es/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths)) (checked in this PR https://github.com/alice-biometrics/petisco/pull/249)