### PR TITLE
fix: restrict Flask version to <=2.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
     zip_safe=False,
     extras_require={
         "flask": [
+            "flask<=2.1.3",
             "connexion==2.6.0",
             "swagger-ui-bundle>=0.0.2",
             "Flask-Cors==3.0.7",


### PR DESCRIPTION
v2.2.0 breaks our services