### PR TITLE
feat: hide "private"  paths from Swagger UI

### DIFF
--- a/petisco/frameworks/flask/application/flask_application.py
+++ b/petisco/frameworks/flask/application/flask_application.py
@@ -1,4 +1,5 @@
 import connexion
+import yaml
 from flask_bcrypt import Bcrypt
 
 from flask_cors import CORS
@@ -26,7 +27,16 @@ class FlaskApplication(IApplication):
         self.app.app.config["BCRYPT_HANDLE_LONG_PASSWORDS"] = True
         self.bcrypt = Bcrypt(self.app.app)
         self.app.app.json_encoder = JSONEncoder
-        self.app.add_api(self.config_file, arguments={"title": self.application_name})
+        self.app.add_api(
+            self.config_file,
+            arguments={"title": self.application_name},
+            options={"serve_spec": False},
+        )
+        self.app.app.add_url_rule(
+            rule=f"/{self.application_name}/openapi.json",
+            view_func=self._openapi_json,
+            endpoint="_openapi_json",
+        )
 
     def start(self):
         self.app.run(port=self.port)
@@ -36,5 +46,23 @@ class FlaskApplication(IApplication):
 
     def get_app(self):
         return self.app
+
+    def _openapi_json(self):
+        openapi_yaml_path = f"{self.app.specification_dir}/{self.config_file}"
+
+        with open(openapi_yaml_path) as openapi_yaml:
+            openapi = yaml.safe_load(openapi_yaml)
+
+        hidden_endpoints = []
+        for path, methods in openapi["paths"].items():
+            for method, endpoint in methods.items():
+                print(f"{path} {method}")
+                if endpoint.get("x-hidden"):
+                    hidden_endpoints.append((path, method))
+
+        for path, method in hidden_endpoints:
+            del openapi["paths"][path][method]
+
+        return openapi
 
     config = property(get_config)


### PR DESCRIPTION
Following this approach:
https://medium.com/ntropy-network/hiding-endpoints-from-swaggerui-while-supporting-with-connexion-960a6ede41cf