### PR TITLE
fix: avoid exception when traceback is None

### DIFF
--- a/petisco/extra/slack/application/notifier/exception_blocks_slack_notifier_message_converter.py
+++ b/petisco/extra/slack/application/notifier/exception_blocks_slack_notifier_message_converter.py
@@ -100,6 +100,8 @@ class ExceptionBlocksSlackNotifierMessageConverter(SlackNotifierMessageConverter
             traceback_max_length = 3000 - len(text_error) - len(traceback_base_str)
             text_error += traceback_base_str.format(
                 notifier_exception_message.traceback[:traceback_max_length]
+                if notifier_exception_message.traceback
+                else "None"
             )
 
             error_block = {


### PR DESCRIPTION
### TypeError: 'NoneType' object is not subscriptable

![Captura de pantalla 2023-06-27 a las 12 22 12](https://github.com/alice-biometrics/petisco/assets/59612324/4ab77261-00e9-44e4-91b1-1675e130ab6a)

