### PR TITLE
fix: cast event version to int regardless of type

### DIFF
--- a/petisco/event/shared/domain/event.py
+++ b/petisco/event/shared/domain/event.py
@@ -109,7 +109,7 @@ class Event:
         else:
             event_dictionary["event_type"] = "domain_event"
 
-        if "version" in data and isinstance(data["version"], str):
+        if "version" in data:
             event_dictionary["event_version"] = int(data["version"])
 
         if "occurred_on" in data and isinstance(data["occurred_on"], str):


### PR DESCRIPTION
As a result of these changes, the versions began to be published as integers in elastic instead of strings. Therefore, in petisco v0, event version parsing was broken.

https://github.com/alice-biometrics/petisco/pull/354/files#diff-ff664927556574395a1aa44764769a15701af0e32778a7c52811d9dfa816ae1c