### PR TITLE
fix: replace utcnow() with now(timezone.utc)

### DIFF
--- a/petisco/base/application/application.py
+++ b/petisco/base/application/application.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, List, Union
 
 from loguru import logger
@@ -118,7 +118,9 @@ class Application(BaseSettings):
         return info
 
     def was_deploy_few_minutes_ago(self, minutes: int = 25) -> bool:
-        return datetime.utcnow() < self.deployed_at + timedelta(minutes=minutes)
+        return datetime.now(timezone.utc) < self.deployed_at + timedelta(
+            minutes=minutes
+        )
 
     def publish_domain_event(self, domain_event: DomainEvent) -> None:
         try:

--- a/petisco/base/domain/message/message.py
+++ b/petisco/base/domain/message/message.py
@@ -1,6 +1,6 @@
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Union, cast
 
 from pydantic import BaseModel

--- a/petisco/base/domain/message/message.py
+++ b/petisco/base/domain/message/message.py
@@ -49,7 +49,7 @@ class Message(BaseModel, extra="allow"):
             self._message_version = 1  # noqa
 
         if not hasattr(self, "_message_occurred_on"):
-            self._message_occurred_on = datetime.utcnow()  # noqa
+            self._message_occurred_on = datetime.now(timezone.utc)  # noqa
 
         if not hasattr(self, "_message_attributes"):
             self._message_attributes = dict()  # noqa

--- a/petisco/base/domain/message/message.py
+++ b/petisco/base/domain/message/message.py
@@ -129,9 +129,11 @@ class Message(BaseModel, extra="allow"):
         self._message_name = str(kwargs.get("type"))
         self._message_version = int(kwargs.get("version", 1))
         self._message_occurred_on = (
-            datetime.strptime(str(kwargs.get("occurred_on")), TIME_FORMAT)
+            datetime.strptime(str(kwargs.get("occurred_on")), TIME_FORMAT).replace(
+                tzinfo=timezone.utc
+            )
             if kwargs.get("occurred_on")
-            else datetime.now()
+            else datetime.now(timezone.utc)
         )
 
         attributes = (

--- a/petisco/cli/petisco.py
+++ b/petisco/cli/petisco.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from petisco import __version__
@@ -83,7 +83,7 @@ def main() -> None:
             return
 
         if args.utcnow:
-            print(datetime.utcnow())
+            print(datetime.now(timezone.utc))
             return
 
         if args.rename_template_replacement:

--- a/tests/modules/base/application/controller/unit/test_controller.py
+++ b/tests/modules/base/application/controller/unit/test_controller.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import patch
 
@@ -40,7 +40,7 @@ def set_shared_error_map(shared_error_map: ErrorMap) -> None:
         name="test_controller",
         organization="test",
         version="1",
-        deployed_at=datetime.utcnow(),
+        deployed_at=datetime.now(timezone.utc),
         force_recreation=True,
         shared_error_map=shared_error_map,
     )

--- a/tests/modules/base/application/test_application.py
+++ b/tests/modules/base/application/test_application.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, NoReturn
 
 import pytest
@@ -85,7 +85,7 @@ class TestApplication:
             name="service",
             version="1.0.0",
             organization="acme",
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
         ).configure(testing=True)
 
         assert DEFAULT_AVAILABLE_DEPENDENCIES == Container.get_available_dependencies()
@@ -96,7 +96,7 @@ class TestApplication:
             name="service",
             version="1.0.0",
             organization="acme",
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
         )
 
         assert ApplicationInfo().name == "service"
@@ -115,7 +115,7 @@ class TestApplication:
             version="1.0.0",
             organization="acme",
             dependencies_provider=dependencies_provider,
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
         ).configure()
 
         assert (
@@ -135,7 +135,7 @@ class TestApplication:
                 version="1.0.0",
                 organization="acme",
                 dependencies_provider=dependencies_provider,
-                deployed_at=datetime.utcnow(),
+                deployed_at=datetime.now(timezone.utc),
             ).configure()
 
     @testing_with_empty_container
@@ -148,7 +148,7 @@ class TestApplication:
             version="1.0.0",
             organization="acme",
             dependencies_provider=dependencies_provider,
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
         ).configure(overwrite_dependencies=True)
 
         assert DEFAULT_AVAILABLE_DEPENDENCIES == Container.get_available_dependencies()
@@ -169,7 +169,7 @@ class TestApplication:
             version="1.0.0",
             organization="acme",
             dependencies_provider=dependencies_provider,
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
         ).configure()
 
         assert (
@@ -192,7 +192,7 @@ class TestApplication:
                 MyApplicationConfigurer(),
                 MyApplicationConfigurer(execute_after_dependencies=True),
             ],
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
         ).configure()
 
     @testing_with_empty_container
@@ -207,7 +207,7 @@ class TestApplication:
                 version="1.0.0",
                 organization="acme",
                 configurers=[MyApplicationConfigurer()],
-                deployed_at=datetime.utcnow(),
+                deployed_at=datetime.now(timezone.utc),
             ).configure()
         assert "Our Error" in str(excinfo.value)
 
@@ -221,7 +221,7 @@ class TestApplication:
             version="1.0.0",
             organization="acme",
             dependencies_provider=dependencies_provider,
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
         )
         application.configure(overwrite_dependencies=True)
 

--- a/tests/modules/base/domain/messages/unit/test_command.py
+++ b/tests/modules/base/domain/messages/unit/test_command.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -81,7 +81,7 @@ class TestCommand:
     def should_create_command_with_most_conflicting_domain_event(  # noqa
         self,
     ):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         command = MostConflictingCommand(
             name="given-name",
             version=2,

--- a/tests/modules/base/domain/messages/unit/test_domain_event.py
+++ b/tests/modules/base/domain/messages/unit/test_domain_event.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -127,7 +127,7 @@ class TestDomainEvent:
     def should_create_domain_event_with_most_conflicting_domain_event(  # noqa
         self,
     ):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         domain_event = MostConflictingDomainEvent(
             name="given-name",
             version=2,

--- a/tests/modules/base/domain/messages/unit/test_message.py
+++ b/tests/modules/base/domain/messages/unit/test_message.py
@@ -1,3 +1,5 @@
+from datetime import timezone
+
 import pytest
 
 from petisco import Message
@@ -56,16 +58,37 @@ class TestMessage:
             != message_2.get_message_attributes()["bar"]
         )
 
-    def should_check_timestamp_from_ocurred_on_datetime(self):  # noqa
+    def should_check_ocurred_on_datetime_has_timezone(self):  # noqa
         message = Message()
 
-        original_timestamp = message.get_message_occurred_on().timestamp()
+        occurred_on = message.get_message_occurred_on()
+
+        assert occurred_on.tzinfo == timezone.utc
+
+    def should_check_ocurred_on_datetime_has_timezone_when_format_and_from_format(
+        self,
+    ):  # noqa
+        message = Message()
 
         message_json = message.format_json()
         retrieved_message = Message.from_format(message_json)
 
-        retrieved_timestamp = message.get_message_occurred_on().timestamp()
+        occurred_on = message.get_message_occurred_on()
+        retrieved_occurred_on = retrieved_message.get_message_occurred_on()
+
+        assert occurred_on.tzinfo == timezone.utc
+        assert retrieved_occurred_on.tzinfo == timezone.utc
 
         assert message == retrieved_message
         assert id(message) != id(retrieved_message)
-        assert original_timestamp == retrieved_timestamp
+        assert occurred_on == retrieved_occurred_on
+
+    def should_check_ocurred_on_datetime_has_timezone_when_is_old_format(self):  # noqa
+        message_json_with_occurred_on_without_timezone = '{"data": {"id": "69d71598-4920-4a59-b006-e4caa3316932", "type": "message", "type_message": "message", "version": 1, "occurred_on": "2023-09-20 10:09:57.220432", "attributes": {}, "meta": {}}}'
+
+        retrieved_message = Message.from_format(
+            message_json_with_occurred_on_without_timezone
+        )
+        retrieved_occurred_on = retrieved_message.get_message_occurred_on()
+
+        assert retrieved_occurred_on.tzinfo == timezone.utc

--- a/tests/modules/extra/fastapi/controller/integration/test_fastapi_application.py
+++ b/tests/modules/extra/fastapi/controller/integration/test_fastapi_application.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from fastapi import Depends, FastAPI
@@ -52,7 +52,7 @@ class TestFastapiApplication:
             name="Test",
             version="1.0.0",
             organization="petisco",
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
             fastapi_configurer=fastapi_configurer,
         )
         application.get_app()
@@ -65,7 +65,7 @@ class TestFastapiApplication:
                 name="Test",
                 version="1.0.0",
                 organization="petisco",
-                deployed_at=datetime.utcnow(),
+                deployed_at=datetime.now(timezone.utc),
                 fastapi_configurer=fastapi_configurer,
                 ensure_async_routers=True,
             )
@@ -76,7 +76,7 @@ class TestFastapiApplication:
             name="Test",
             version="1.0.0",
             organization="petisco",
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
             fastapi_configurer=fastapi_configurer,
         )
         app = application.get_app()
@@ -97,7 +97,7 @@ class TestFastapiApplication:
             name="Test",
             version="1.0.0",
             organization="petisco",
-            deployed_at=datetime.utcnow(),
+            deployed_at=datetime.now(timezone.utc),
             fastapi_configurer=fastapi_configurer,
         )
         app = application.get_app()


### PR DESCRIPTION
Naïve datetimes can provoke unexpected results with some methods that assume local times