### PR TITLE
feat: improve lost connection notifications in rabbitmq consumer

### DIFF
--- a/petisco/extra/rabbitmq/application/message/consumer/rabbitmq_message_consumer.py
+++ b/petisco/extra/rabbitmq/application/message/consumer/rabbitmq_message_consumer.py
@@ -169,7 +169,14 @@ class RabbitMqMessageConsumer(MessageConsumer):
         notifier = Container.get(Notifier)
         error = UnknownError.from_exception(
             exception=exception,
-            arguments={"exchange": self.exchange_name, "service": self.service},
+            arguments={
+                "exchange": self.exchange_name,
+                "service": self.service,
+                "subscribers": {
+                    queue: str(item.subscriber)
+                    for queue, item in self.subscribers.items()
+                },
+            },
         )
         notifier_exception_message = NotifierExceptionMessage.from_unknown_error(
             error, title="Lost connection exception in RabbitMQ consumer"

--- a/tests/modules/extra/rabbitmq/application/message/consumer/test_rabbitmq_message_consumer.py
+++ b/tests/modules/extra/rabbitmq/application/message/consumer/test_rabbitmq_message_consumer.py
@@ -72,6 +72,14 @@ class TestRabbitMqMessageConsumer:
             dependencies_provider=get_default_notifier_dependencies,
         )
         application.configure()
+        subscribers = [
+            MessageSubscriberMother.domain_event_subscriber(
+                domain_event_type=type(DomainEventUserCreatedMother.random()),
+                handler=lambda a: a,
+            )
+        ]
+        consumer = RabbitMqMessageConsumerMother.default()
+        consumer.add_subscribers(subscribers)
         with pytest.raises(ConnectionClosedByClient):
             with patch(
                 "pika.adapters.blocking_connection.BlockingChannel.start_consuming",
@@ -80,7 +88,6 @@ class TestRabbitMqMessageConsumer:
                 with patch.object(
                     NotImplementedNotifier, "publish_exception"
                 ) as notifier_mock:
-                    consumer = RabbitMqMessageConsumerMother.default()
                     consumer._start()
 
         notifier_mock.assert_called_once()

--- a/tests/modules/extra/rabbitmq/application/message/consumer/test_rabbitmq_message_consumer.py
+++ b/tests/modules/extra/rabbitmq/application/message/consumer/test_rabbitmq_message_consumer.py
@@ -78,6 +78,8 @@ class TestRabbitMqMessageConsumer:
                 handler=lambda a: a,
             )
         ]
+        configurer = RabbitMqMessageConfigurerMother.with_retry_ttl_10ms()
+        configurer.configure_subscribers(subscribers)
         consumer = RabbitMqMessageConsumerMother.default()
         consumer.add_subscribers(subscribers)
         with pytest.raises(ConnectionClosedByClient):
@@ -94,6 +96,7 @@ class TestRabbitMqMessageConsumer:
 
         consumer.stop()
         application.clear()
+        configurer.clear()
 
     @testing_with_rabbitmq
     def should_fail_and_notify_after_try_to_reconnect_max_specified_attempts(self):


### PR DESCRIPTION
Current notifications are missing some information to ease debugging
With this change we would identify the subscribers that were associated with that consumer who lost the connection