### PR TITLE
chore: avoid enabling confirm_delivery on channels more than once

### DIFF
--- a/petisco/extra/rabbitmq/application/message/bus/rabbitmq_command_bus.py
+++ b/petisco/extra/rabbitmq/application/message/bus/rabbitmq_command_bus.py
@@ -52,10 +52,10 @@ class RabbitMqCommandBus(CommandBus):
         try:
             check_chaos_publication()
             channel = self.connector.get_channel(self.rabbitmq_key)
-            for command in commands:
+            for i, command in enumerate(commands):
                 self._check_is_command(command)
                 command = command.update_meta(meta)
-                self.publisher.execute(channel, command)
+                self.publisher.execute(channel, command, first_time=i == 0)
                 if channel.is_open and not isinstance(self.connector, RabbitMqConsumerConnector):
                     channel.close()
                 dispatched_commands.append(command)

--- a/petisco/extra/rabbitmq/application/message/bus/rabbitmq_domain_event_bus.py
+++ b/petisco/extra/rabbitmq/application/message/bus/rabbitmq_domain_event_bus.py
@@ -51,10 +51,10 @@ class RabbitMqDomainEventBus(DomainEventBus):
         try:
             check_chaos_publication()
             channel = self.connector.get_channel(self.rabbitmq_key)
-            for domain_event in domain_events:
+            for i, domain_event in enumerate(domain_events):
                 self._check_is_domain_event(domain_event)
                 domain_event = domain_event.update_meta(meta)
-                self.publisher.execute(channel, domain_event)
+                self.publisher.execute(channel, domain_event, first_time=i == 0)
                 published_domain_event.append(domain_event)
             if channel.is_open and not isinstance(self.connector, RabbitMqConsumerConnector):
                 channel.close()

--- a/petisco/extra/rabbitmq/application/message/bus/rabbitmq_message_publisher.py
+++ b/petisco/extra/rabbitmq/application/message/bus/rabbitmq_message_publisher.py
@@ -19,11 +19,15 @@ class RabbitMqMessagePublisher:
         channel: BlockingChannel,
         message: Message,
         routing_key: Union[str, None] = None,
+        first_time: bool = False,
     ) -> None:
         if routing_key is None:
             routing_key = RabbitMqMessageQueueNameFormatter.format(message, exchange_name=self._exchange_name)
 
-        channel.confirm_delivery()
+        if first_time:
+            # Confirm delivery should be enabled just once. Source: https://www.rabbitmq.com/tutorials/tutorial-seven-java#enabling-publisher-confirms-on-a-channel
+            # Otherwise with Pika we get lots of error messages
+            channel.confirm_delivery()
         channel.basic_publish(
             exchange=self._exchange_name,
             routing_key=routing_key,

--- a/tests/modules/extra/rabbitmq/application/message/bus/test_rabbitmq_domain_event_bus.py
+++ b/tests/modules/extra/rabbitmq/application/message/bus/test_rabbitmq_domain_event_bus.py
@@ -58,11 +58,11 @@ class TestRabbitMqDomainEventBus:
 
         bus = RabbitMqDomainEventBusMother.with_info_id()
         with mock.patch.object(BlockingChannel, "basic_publish") as mock_channel_publish, mock.patch.object(
-            bus, "execute", wraps=bus.execute
-        ) as wrapped_bus:
+            bus.publisher, "execute", wraps=bus.publisher.execute
+        ) as mock_publisher:
             bus.publish(domain_event_list)
-            wrapped_bus.assert_any_call(ANY, domain_event_list[0], True)
-            wrapped_bus.assert_any_call(ANY, domain_event_list[1], False)
+            mock_publisher.assert_any_call(ANY, domain_event_list[0], first_time=True)
+            mock_publisher.assert_any_call(ANY, domain_event_list[1], first_time=False)
 
         assert mock_channel_publish.call_count == events_number
 


### PR DESCRIPTION
You are only supposed to enable Confirms on the channel once (see: https://www.rabbitmq.com/tutorials/tutorial-seven-java#enabling-publisher-confirms-on-a-channel)

Since we create the channel on the publish method of the command and event buses I'm guessing this was only happening when publishing multiple commands/events