### PR TITLE
feat: allow base models as Message attributes

### DIFF
--- a/petisco/base/domain/message/message.py
+++ b/petisco/base/domain/message/message.py
@@ -112,8 +112,10 @@ class Message(BaseModel, extra="allow"):
             serialized_value = attribute
             if isinstance(attribute, (Uuid, ValueObject)):
                 serialized_value = attribute.value
-            if isinstance(attribute, datetime):
+            elif isinstance(attribute, datetime):
                 serialized_value = attribute.strftime(TIME_FORMAT)
+            elif isinstance(attribute, BaseModel):
+                serialized_value = attribute.model_dump()
             attributes[key] = serialized_value
         return attributes
 

--- a/tests/modules/base/domain/messages/unit/test_message.py
+++ b/tests/modules/base/domain/messages/unit/test_message.py
@@ -1,6 +1,7 @@
 from datetime import timezone
 
 import pytest
+from pydantic.main import BaseModel
 
 from petisco import Message
 from tests.modules.base.mothers.message_mother import MessageMother
@@ -110,3 +111,18 @@ class TestMessage:
 
         assert len(messages) == 5
         assert len(unique_messages) == 4
+
+    def should_format_message_with_base_model(
+        self,
+    ):  # noqa
+        class Model(BaseModel):
+            model_att: str
+
+        message = Message()
+        message._message_attributes = {"base_model": Model(model_att="att")}
+
+        message_json = message.format_json()
+        retrieved_message = Message.from_format(message_json)
+
+        assert message == retrieved_message
+

--- a/tests/modules/base/domain/messages/unit/test_message.py
+++ b/tests/modules/base/domain/messages/unit/test_message.py
@@ -112,9 +112,7 @@ class TestMessage:
         assert len(messages) == 5
         assert len(unique_messages) == 4
 
-    def should_format_message_with_base_model(
-        self,
-    ):  # noqa
+    def should_format_message_with_base_model(self):
         class Model(BaseModel):
             model_att: str
 

--- a/tests/modules/base/domain/messages/unit/test_message.py
+++ b/tests/modules/base/domain/messages/unit/test_message.py
@@ -113,11 +113,11 @@ class TestMessage:
         assert len(unique_messages) == 4
 
     def should_format_message_with_base_model(self):
-        class Model(BaseModel):
-            model_att: str
+        class Model1(BaseModel):
+            att1: str
 
         message = Message()
-        message._message_attributes = {"base_model": Model(model_att="att")}
+        message._message_attributes = {"base_model": Model1(att1="att")}
 
         message_json = message.format_json()
         retrieved_message = Message.from_format(message_json)


### PR DESCRIPTION
Para poder definir BaseModels como atributos de eventos y que no pase esto:

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/petisco/base/application/use_case/meta_use_case.py", line 20, in wrapped
    return method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/src/kyc/selfie/upload/application/registration_selfie_uploader.py", line 84, in execute
    injection_result = selfie_injection_check(
                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/meiga/decorators/early_return.py", line 31, in _early_return
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/src/kyc/selfie/upload/application/selfie_injection/selfie_injection_check.py", line 42, in selfie_injection_check
    return injection_checker.execute(device_info=device_info, media_data=media_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/src/kyc/shared/injection_check/application/injection_checker_v2.py", line 60, in execute
    device_metadata, sdk_metadata_injection = self.validate_ios_mobile_sdk(
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/src/kyc/shared/injection_check/application/injection_checker_v2.py", line 292, in validate_ios_mobile_sdk
    self.domain_event_bus.publish(
  File "/usr/local/lib/python3.12/site-packages/alicepetisco/message/transaction_domain_event_bus.py", line 61, in publish
    self.transactional_bus.publish(filtered_domain_events)
  File "/usr/local/lib/python3.12/site-packages/alicepetisco/message/redis_user_domain_event_bus.py", line 34, in publish
    self.save(updated_domain_events)
  File "/usr/local/lib/python3.12/site-packages/alicepetisco/message/redis_user_domain_event_bus.py", line 41, in save
    data = [domain_event.format_json() for domain_event in domain_events]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/petisco/base/domain/message/message.py", line 91, in format_json
    return json.dumps(self.format())
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type EmulatorReason is not JSON serializable
```